### PR TITLE
Add support for Vipps eCom partner requests

### DIFF
--- a/ecom/client.go
+++ b/ecom/client.go
@@ -3,11 +3,12 @@ package ecom
 import (
 	"context"
 	"fmt"
+	"net/http"
+	"net/url"
+
 	"github.com/go-kit/kit/log"
 	"github.com/torfjor/go-vipps"
 	"github.com/torfjor/go-vipps/internal"
-	"net/http"
-	"net/url"
 )
 
 type Doer interface {
@@ -73,6 +74,8 @@ func (c *Client) CancelPayment(ctx context.Context, cmd CancelPaymentCommand) (*
 		return nil, err
 	}
 
+	req.Header.Add("Merchant-Serial-Number", cmd.MerchantSerialNumber)
+
 	err = c.APIClient.Do(req, &res)
 	if err != nil {
 		return nil, wrapErr(err)
@@ -104,6 +107,7 @@ func (c *Client) CapturePayment(ctx context.Context, cmd CapturePaymentCommand) 
 		return nil, err
 	}
 	req.Header.Add("X-Request-ID", cmd.IdempotencyKey)
+	req.Header.Add("Merchant-Serial-Number", cmd.MerchantSerialNumber)
 	err = c.APIClient.Do(req, &res)
 	if err != nil {
 		return nil, wrapErr(err)
@@ -113,7 +117,7 @@ func (c *Client) CapturePayment(ctx context.Context, cmd CapturePaymentCommand) 
 }
 
 // GetPayment gets a Payment.
-func (c *Client) GetPayment(ctx context.Context, orderID string) (*Payment, error) {
+func (c *Client) GetPayment(ctx context.Context, orderID string, merchantSerialNumber string) (*Payment, error) {
 	endpoint := fmt.Sprintf("%s/%s/%s/details", c.BaseURL, ecomEndpoint, orderID)
 	method := http.MethodGet
 	res := Payment{}
@@ -123,6 +127,7 @@ func (c *Client) GetPayment(ctx context.Context, orderID string) (*Payment, erro
 		return nil, err
 	}
 
+	req.Header.Add("Merchant-Serial-Number", merchantSerialNumber)
 	err = c.APIClient.Do(req, &res)
 	if err != nil {
 		return nil, wrapErr(err)
@@ -145,6 +150,8 @@ func (c *Client) InitiatePayment(ctx context.Context, cmd InitiatePaymentCommand
 	if err != nil {
 		return nil, err
 	}
+
+	req.Header.Add("Merchant-Serial-Number", cmd.MerchantInfo.MerchantSerialNumber)
 
 	err = c.APIClient.Do(req, &res)
 	if err != nil {
@@ -177,6 +184,7 @@ func (c *Client) RefundPayment(ctx context.Context, cmd RefundPaymentCommand) (*
 		return nil, err
 	}
 	req.Header.Add("X-Request-ID", cmd.IdempotencyKey)
+	req.Header.Add("Merchant-Serial-Number", cmd.MerchantSerialNumber)
 	err = c.APIClient.Do(req, &res)
 	if err != nil {
 		return nil, wrapErr(err)

--- a/ecom/ecom.go
+++ b/ecom/ecom.go
@@ -117,7 +117,7 @@ type UserDetails struct {
 // ShippingDetails represents details for a shipping method
 type ShippingDetails struct {
 	Address          Address `json:"address,omitempty"`
-	ShippingCost     int     `json:"shippingCost,omitempty"`
+	ShippingCost     string  `json:"shippingCost,omitempty"`
 	ShippingMethod   string  `json:"shippingMethod,omitempty"`
 	ShippingMethodID string  `json:"shippingMethodId,omitempty"`
 }

--- a/go.sum
+++ b/go.sum
@@ -74,7 +74,6 @@ github.com/golang/glog v0.0.0-20160126235308-23def4e6c14b/go.mod h1:SBH7ygxi8pfU
 github.com/golang/groupcache v0.0.0-20160516000752-02826c3e7903/go.mod h1:cIg4eruTrX1D+g88fzRXU5OdNfaM+9IcxsU14FzY7Hc=
 github.com/golang/groupcache v0.0.0-20190702054246-869f871628b6/go.mod h1:cIg4eruTrX1D+g88fzRXU5OdNfaM+9IcxsU14FzY7Hc=
 github.com/golang/mock v1.1.1/go.mod h1:oTYuIxOrZwtPieC+H1uAHpcLFnEyAGVDL/k47Jfbm0A=
-github.com/golang/protobuf v1.2.0 h1:P3YflyNX/ehuJFLhxviNdFxQPkGK5cDcApsge1SqnvM=
 github.com/golang/protobuf v1.2.0/go.mod h1:6lQm79b+lXiMfvg/cZm0SGofjICqVBUtrP5yJMmIC1U=
 github.com/golang/protobuf v1.3.1/go.mod h1:6lQm79b+lXiMfvg/cZm0SGofjICqVBUtrP5yJMmIC1U=
 github.com/golang/protobuf v1.3.2 h1:6nsPYzhq5kReh6QImI3k5qWzO4PEbvbIW2cwSfR/6xs=
@@ -92,7 +91,6 @@ github.com/google/uuid v1.0.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+
 github.com/gopherjs/gopherjs v0.0.0-20181017120253-0766667cb4d1/go.mod h1:wJfORRmW1u3UXTncJ5qlYoELFm8eSnnEO6hX4iZ3EWY=
 github.com/gorilla/context v1.1.1/go.mod h1:kBGZzfjB9CEq2AlWe17Uuf7NDRt0dE0s8S51q0aT7Yg=
 github.com/gorilla/mux v1.6.2/go.mod h1:1lud6UwP+6orDFRuTfBEV8e9/aOM/c4fVVCaMa2zaAs=
-github.com/gorilla/mux v1.7.3 h1:gnP5JzjVOuiZD07fKKToCAOjS0yOpj/qPETTXCCS6hw=
 github.com/gorilla/mux v1.7.3/go.mod h1:1lud6UwP+6orDFRuTfBEV8e9/aOM/c4fVVCaMa2zaAs=
 github.com/gorilla/websocket v0.0.0-20170926233335-4201258b820c/go.mod h1:E7qHFY5m1UJ88s3WnNqhKjPHQ0heANvMoAMk2YaljkQ=
 github.com/grpc-ecosystem/go-grpc-middleware v1.0.1-0.20190118093823-f849b5445de4/go.mod h1:FiyG127CGDf3tlThmgyCl78X/SZQqEOJBCDaAfeWzPs=
@@ -274,7 +272,6 @@ golang.org/x/net v0.0.0-20181023162649-9b4f9f5ad519/go.mod h1:mL1N/T3taQHkDXs73r
 golang.org/x/net v0.0.0-20181114220301-adae6a3d119a/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=
 golang.org/x/net v0.0.0-20181201002055-351d144fa1fc/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=
 golang.org/x/net v0.0.0-20181220203305-927f97764cc3/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=
-golang.org/x/net v0.0.0-20190108225652-1e06a53dbb7e h1:bRhVy7zSSasaqNksaRZiA5EEI+Ei4I1nO5Jh72wfHlg=
 golang.org/x/net v0.0.0-20190108225652-1e06a53dbb7e/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=
 golang.org/x/net v0.0.0-20190125091013-d26f9f9a57f3/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=
 golang.org/x/net v0.0.0-20190213061140-3a22650c66bd/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=
@@ -291,11 +288,9 @@ golang.org/x/oauth2 v0.0.0-20200107190931-bf48bf16ab8d h1:TzXSXBo42m9gQenoE3b9BG
 golang.org/x/oauth2 v0.0.0-20200107190931-bf48bf16ab8d/go.mod h1:gOpvHmFTYa4IltrdGE7lF6nIHvwfUNPOp7c8zoXwtLw=
 golang.org/x/sync v0.0.0-20180314180146-1d60e4601c6f/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.0.0-20181108010431-42b317875d0f/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
-golang.org/x/sync v0.0.0-20181221193216-37e7f081c4d4 h1:YUO/7uOKsKeq9UokNS62b8FYywz3ker1l1vDZRCRefw=
 golang.org/x/sync v0.0.0-20181221193216-37e7f081c4d4/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.0.0-20190227155943-e225da77a7e6/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.0.0-20190423024810-112230192c58/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
-golang.org/x/sync v0.0.0-20190911185100-cd5d95a43a6e h1:vcxGaoTs7kV8m5Np9uUNQin4BrLOthgV7252N8V+FwY=
 golang.org/x/sync v0.0.0-20190911185100-cd5d95a43a6e/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sys v0.0.0-20180823144017-11551d06cbcc/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20180830151530-49385e6e1522/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=


### PR DESCRIPTION
To be able to support Vipps eCom partner to be able to make payments on behalf of merchants the Merchant-Serial-Number header needs to be included in the requests.

This is now included in all the implemented requests for ecom. However this breaks backwards compability on the "getPayment" function, since this did not have access to the MSN 